### PR TITLE
Disable System Accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This Puppet module provides secure configuration of your base OS with hardening.
   set to any option line (as a string) that you want to pass to passwdqc
 * `allow_change_user = false`
   if a user may use `su` to change his login
+* `ignore_users = []`
+  array of system user accounts that should _not be_ hardened (password disabled and shell set to `/usr/sbin/nologin`)
 * `enable_module_loading = true`
   true if you want to allowed to change kernel modules once the system is running (eg `modprobe`, `rmmod`)
 * `load_modules = []`

--- a/lib/facter/retrieve_system_users.rb
+++ b/lib/facter/retrieve_system_users.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+
+# Try to read UID_MIN from /etc/login.defs to caluclate SYS_UID_MAX
+# if that fails set some predefined values based on os_family fact.
+logindefs = '/etc/login.defs'
+
+if File.exist?(logindefs)
+  f = File.open(logindefs, 'r')
+  su_maxid = f.each do |line|
+    break Regexp.last_match[1].to_i - 1 if line =~ /^\s*UID_MIN\s+(\d+)(\s*#.*)?$/
+  end
+  f.close
+else
+  case Facter.value(:osfamily)
+  when 'Debian', 'OpenBSD', 'FreeBSD'
+    su_maxid = 999
+  else
+    su_maxid = 499
+  end
+end
+
+# Retrieve all system users and build custom fact with the usernames
+# using comma separated values.
+Facter.add(:retrieve_system_users) do
+  sys_users = []
+  Puppet::Type.type('user').instances.find_all do |user|
+    user_value = user.retrieve
+    sys_users.push(user.name) unless user_value[user.property(:uid)].to_i > su_maxid
+  end
+  setcode do
+    sys_users.join(',')
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class os_hardening(
   $allow_login_without_home = false,
 
   $allow_change_user        = false,
+  $ignore_users             = [],
 
   $passwdqc_enabled         = true,
   $auth_retries             = 5,
@@ -79,6 +80,7 @@ class os_hardening(
   }
   class {'os_hardening::minimize_access':
     allow_change_user => $allow_change_user,
+    ignore_users      => $ignore_users,
   }
   class {'os_hardening::pam':
     passwdqc_enabled  => $passwdqc_enabled,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,10 @@ class os_hardening(
   $enable_core_dump         = false,
   $enable_stack_protection  = true,
 ) {
+  # Validate
+  # --------
+  validate_array($ignore_users)
+
   # Prepare
   # -------
 

--- a/manifests/minimize_access.pp
+++ b/manifests/minimize_access.pp
@@ -10,7 +10,10 @@
 # Configures profile.conf.
 #
 class os_hardening::minimize_access (
-  $allow_change_user = false,
+  $allow_change_user   = false,
+  $always_ignore_users =
+    ['root','sync','shutdown','halt'],
+  $ignore_users        = [],
 ){
   # from which folders to remove public access
   $folders = [
@@ -44,6 +47,22 @@ class os_hardening::minimize_access (
       group => root,
       mode  => '0750',
     }
+  }
+
+  # retrieve system users through custom fact
+  $system_users = split($::retrieve_system_users, ',')
+
+  # build array of usernames we need to verify/change
+  $ignore_users_arr = union($always_ignore_users, $ignore_users)
+
+  # build a target array with usernames to verify/change
+  $target_system_users = difference($system_users, $ignore_users_arr)
+
+  # ensure accounts are locked (no password) and use nologin shell
+  user { $target_system_users:
+    ensure   => present,
+    shell    => '/usr/sbin/nologin',
+    password => '*',
   }
 
 }


### PR DESCRIPTION
As per CIS-CAT also system accounts should be hardened, their shell set to /usr/sbin/nologin and their password locked, so I made a few changes to support that in this module.

Could not find any section on how to contribute so let me know if this is acceptable or not or would you want something approached in different way.

 