### PR TITLE
add support for limiting password re-use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ This Puppet module provides secure configuration of your base OS with hardening.
   true if you want to use strong password checking in PAM using passwdqc
 * `passwdqc_options = "min=disabled,disabled,16,12,8"`
   set to any option line (as a string) that you want to pass to passwdqc
+* `manage_pam_unix = false`
+  true if you want pam_unix managed by this module
+* `enable_pw_history = true`
+  true if you want pam_unix to remember password history to prevent reuse of passwords (requires `manage_pam_unix = true`)
+* `pw_remember_last = 5`
+  the number of last passwords (e.g. 5 will prevent user to reuse any of her last 5 passwords)
 * `allow_change_user = false`
   if a user may use `su` to change his login
 * `ignore_users = []`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,9 @@ class os_hardening(
   $auth_retries             = 5,
   $auth_lockout_time        = 600,
   $passwdqc_options         = 'min=disabled,disabled,16,12,8',
+  $manage_pam_unix          = false,
+  $enable_pw_history        = true,
+  $pw_remember_last         = 5,
 
   $root_ttys                =
     ['console','tty1','tty2','tty3','tty4','tty5','tty6'],
@@ -53,6 +56,9 @@ class os_hardening(
   # Validate
   # --------
   validate_array($ignore_users)
+  validate_bool($manage_pam_unix)
+  validate_bool($enable_pw_history)
+  validate_integer($pw_remember_last)
 
   # Prepare
   # -------
@@ -91,6 +97,9 @@ class os_hardening(
     auth_retries      => $auth_retries,
     auth_lockout_time => $auth_lockout_time,
     passwdqc_options  => $passwdqc_options,
+    manage_pam_unix   => $manage_pam_unix,
+    enable_pw_history => $enable_pw_history,
+    pw_remember_last  => $pw_remember_last,
   }
   class {'os_hardening::profile':
     allow_core_dumps => $allow_core_dumps,

--- a/manifests/pam.pp
+++ b/manifests/pam.pp
@@ -14,6 +14,9 @@ class os_hardening::pam (
   $auth_retries = 5,
   $auth_lockout_time = 600,
   $passwdqc_options = 'min=disabled,disabled,16,12,8',
+  $manage_pam_unix = false,
+  $enable_pw_history = false,
+  $pw_remember_last = 5,
 ){
   # prepare package names
   case $::operatingsystem {
@@ -45,6 +48,7 @@ class os_hardening::pam (
       # configure paths
       $passwdqc_path = '/usr/share/pam-configs/passwdqc'
       $tally2_path   = '/usr/share/pam-configs/tally2'
+      $unix_path     = '/usr/share/pam-configs/unix'
 
       # if passwdqc is enabled
       if $passwdqc_enabled == true {
@@ -106,6 +110,24 @@ class os_hardening::pam (
         file { $tally2_path:
           ensure => absent,
           notify => Exec['update-pam'],
+        }
+      }
+
+      #configure pam_unix with password history
+      if $manage_pam_unix {
+        if $enable_pw_history {
+          $pw_history_options = "remember=${pw_remember_last}"
+        }
+        else {
+          $pw_history_options = ''
+        }
+        file { $unix_path:
+          ensure  => present,
+          content => template( 'os_hardening/pam_unix.erb' ),
+          owner   => root,
+          group   => root,
+          mode    => '0640',
+          notify  => Exec['update-pam'],
         }
       }
 

--- a/templates/pam_unix.erb
+++ b/templates/pam_unix.erb
@@ -1,0 +1,23 @@
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+    [success=end default=ignore]    pam_unix.so nullok_secure try_first_pass
+Auth-Initial:
+    [success=end default=ignore]    pam_unix.so nullok_secure
+Account-Type: Primary
+Account:
+    [success=end new_authtok_reqd=done default=ignore]  pam_unix.so
+Account-Initial:
+    [success=end new_authtok_reqd=done default=ignore]  pam_unix.so
+Session-Type: Additional
+Session:
+    required    pam_unix.so
+Session-Initial:
+    required    pam_unix.so
+Password-Type: Primary
+Password:
+    [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass sha512 <%= @pw_history_options %>
+Password-Initial:
+    [success=end default=ignore]    pam_unix.so obscure sha512


### PR DESCRIPTION
this PR adds `manage_pam_unix` toggle option which if set to true generates pam_unix config from erb template. 
if pam_unix is managed through this module user can then enable password history to limit password reuse on their system.